### PR TITLE
Adding optional image fill color for background ellipse fill.

### DIFF
--- a/AGMedallionView/AGMedallionView.h
+++ b/AGMedallionView/AGMedallionView.h
@@ -20,5 +20,6 @@
 @property (nonatomic, strong) UIColor *shadowColor UI_APPEARANCE_SELECTOR;
 @property (nonatomic, assign) CGSize shadowOffset UI_APPEARANCE_SELECTOR;
 @property (nonatomic, assign) CGFloat shadowBlur UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIColor *imageFillColor UI_APPEARANCE_SELECTOR;
 
 @end

--- a/AGMedallionView/AGMedallionView.m
+++ b/AGMedallionView/AGMedallionView.m
@@ -30,7 +30,8 @@
     borderWidth = _borderWidth,
     shadowColor = _shadowColor,
     shadowOffset = _shadowOffset,
-    shadowBlur = _shadowBlur;
+    shadowBlur = _shadowBlur,
+    imageFillColor = _imageFillColor;
 
 - (void)setImage:(UIImage *)image
 {
@@ -75,6 +76,15 @@
     if (_shadowBlur != shadowBlur) {
         _shadowBlur = shadowBlur;
         
+        [self setNeedsDisplay];
+    }
+}
+
+- (void)setImageFillColor:(UIColor *)imageFillColor
+{
+    if (_imageFillColor != imageFillColor) {
+        _imageFillColor = imageFillColor;
+    
         [self setNeedsDisplay];
     }
 }
@@ -201,6 +211,11 @@
     CGContextScaleCTM(contextRef, 1.0, -1.0);
     
     CGContextSaveGState(contextRef);
+    
+    if (self.imageFillColor) {
+        CGContextSetFillColorWithColor(contextRef, self.imageFillColor.CGColor);
+        CGContextFillEllipseInRect(contextRef, rect);
+    }
     
     // Draw image
     CGContextDrawImage(contextRef, rect, imageRef);


### PR DESCRIPTION
I had a need for this in my project so I added it in as optional functionality. I had some transparent-background PNGs as user avatars that needed to go into `AGMedallionView`, but with a background color that didn't expand beyond the circular border. It's all yours, if you'd like it in your project! If so, feel free to tweak it, rename things, make it better, etc.

(And thanks for your work on this library; it's a slick one!)
